### PR TITLE
finalized docker. added ignorefile and chanegd the BASE_API_URL

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.vscode/
+.venv/
+.git/
+.env
+.envrc
+.DS_Store
+logs/
+database/requests.db

--- a/Frontend/streamlit_app.py
+++ b/Frontend/streamlit_app.py
@@ -1,7 +1,7 @@
 import streamlit as st
 import requests
 
-BASE_API_URL = "http://127.0.0.1:8000/logs/json/"
+BASE_API_URL = "http://fastapi:8000/logs/json/"  # Use FastAPI service name instead of localhost
 
 st.title("API Logs Dashboard")
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - "8000:8000"
     volumes:
-      - ./database:/app/database # ✅ Correctly indented!    environment:
+      - ./database:/app/database
     environment:
       - DATABASE_URL=sqlite:///app/database/requests.db
 


### PR DESCRIPTION
instead of using the localhost we used the docker variant.

we refer to the FastApi service inside of docker

we have 2 microservices now.


the streamlit service and the FastApi service that are running in parallel